### PR TITLE
Feat/add short description to projectpartials

### DIFF
--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -7,7 +7,6 @@ export function ProjectsPartial() {
 
   let parsedProjects = projects.map((e) => {
     let project = { ...e.metadata.project };
-    console.log(project);
 
     project.title = e.metadata.title;
     project.description = e.metadata.description;

--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -7,8 +7,10 @@ export function ProjectsPartial() {
 
   let parsedProjects = projects.map((e) => {
     let project = { ...e.metadata.project };
+    console.log(project);
 
     project.title = e.metadata.title;
+    project.description = e.metadata.description;
     project.slug = e.slug;
 
     return project;
@@ -24,6 +26,7 @@ export function ProjectsPartial() {
               <Card
                 key={e.slug}
                 title={e.title}
+                subtitle={e.description}
                 slug={e.slug}
                 color="gray-500"
                 type="project"

--- a/components/src/utils.ts
+++ b/components/src/utils.ts
@@ -14,6 +14,7 @@ function parseFrontmatter(fileContent: string) {
   let frontMatterBlock = match![1];
   let content = fileContent.replace(frontmatterRegex, "").trim();
   let metadata = YAML.parse(frontMatterBlock);
+  console.log(metadata);
 
   return { metadata, content };
 }

--- a/components/src/utils.ts
+++ b/components/src/utils.ts
@@ -14,7 +14,6 @@ function parseFrontmatter(fileContent: string) {
   let frontMatterBlock = match![1];
   let content = fileContent.replace(frontmatterRegex, "").trim();
   let metadata = YAML.parse(frontMatterBlock);
-  console.log(metadata);
 
   return { metadata, content };
 }

--- a/content/projects/_template.mdx
+++ b/content/projects/_template.mdx
@@ -1,5 +1,6 @@
 ---
 title: Example project
+description: Example description (Max 1 sentence)
 links:
   - url: https://example.com
     label: Website

--- a/content/projects/blenderbim-add-on.mdx
+++ b/content/projects/blenderbim-add-on.mdx
@@ -1,5 +1,6 @@
 ---
 title: BlenderBIM Add-on
+description: A cross-platform suite of tools for Building Information Modeling (BIM) built on Blender.
 links:
   - url: https://blenderbim.org
     label: Website
@@ -17,7 +18,16 @@ The industry and general public cannot design, engineer, construction, operate, 
 
 An ecosystem of cross-platform and interface-agnostic tools are built to manipulate BIM data, each tool specialised towards different usecases. A primary graphical native IFC authoring platform is built on top of Blender. Tools include BIM modeling, drawing generation, model auditing, connection to structural simulation software, MEP systems analysis, cost planning, construction scheduling, collection of commissioning and facility management handover data, and more.
 
-<iframe width="1100" height="560" src="https://www.youtube.com/embed/Ooh05WF__80" title="Technical demonstrations of Native IFC authoring with free software - buildingSMART UK+I" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe
+  width="1100"
+  height="560"
+  src="https://www.youtube.com/embed/Ooh05WF__80"
+  title="Technical demonstrations of Native IFC authoring with free software - buildingSMART UK+I"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerpolicy="strict-origin-when-cross-origin"
+  allowfullscreen
+></iframe>
 
 ### Why Open Source?
 

--- a/content/projects/circular-construction-co-pilot.mdx
+++ b/content/projects/circular-construction-co-pilot.mdx
@@ -1,5 +1,6 @@
 ---
 title: Circular Construction Co-Pilot
+description: Accelerating circular construction practices through a digital knowledge hub that adapts to industry needs.
 ---
 
 ### About the project

--- a/content/projects/compas.mdx
+++ b/content/projects/compas.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compas
+description: More infos coming soon
 links:
   - url: https://compas.dev
     label: Website

--- a/content/projects/ifc-model-checker.mdx
+++ b/content/projects/ifc-model-checker.mdx
@@ -1,5 +1,6 @@
 ---
 title: vyssuals
+description: Streamlines data visualization by directly integrating with BIM models and other data sources, enhancing understanding through in-context 3D views.
 ---
 
 ### Problem
@@ -10,9 +11,27 @@ Currently available data visualisation tools are too complex and not well integr
 
 Vyssuals.com is a data visualisation web application that can connect to any data source, including a BIM model from any authoring software, local CSV data, or any web API. When connected, for example, to Revit, its 3D view is utilised to colour elements according to the visualisation created in the web app. This simplifies understanding the charts within the context of your 3D model, eliminating the need to learn new software.
 
-<iframe width="1100" height="560" src="https://www.youtube.com/embed/vEO1-BT1kmY" title="Vyssuals | Design Tweaker" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe
+  width="1100"
+  height="560"
+  src="https://www.youtube.com/embed/vEO1-BT1kmY"
+  title="Vyssuals | Design Tweaker"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerpolicy="strict-origin-when-cross-origin"
+  allowfullscreen
+></iframe>
 
-<iframe width="1100" height="560" src="https://www.youtube.com/embed/vI4c4Y22DZo" title="Vyssuals | Check Structure" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe
+  width="1100"
+  height="560"
+  src="https://www.youtube.com/embed/vI4c4Y22DZo"
+  title="Vyssuals | Check Structure"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerpolicy="strict-origin-when-cross-origin"
+  allowfullscreen
+></iframe>
 
 ### Why open source?
 

--- a/content/projects/lcax-and-epdx.mdx
+++ b/content/projects/lcax-and-epdx.mdx
@@ -1,5 +1,6 @@
 ---
 title: LCAx and EPDx
+description: Facilitates interoperability in sustainability assessments by developing an open data format for LCA results and EPD information, promoting transparent and collaborative environmental impact analysis.
 links:
   - url: https://lcax.kongsgaard.eu
     label: Details about LCAx

--- a/content/projects/speckle.mdx
+++ b/content/projects/speckle.mdx
@@ -1,5 +1,6 @@
 ---
 title: Speckle
+description: Revolutionizes AEC industry collaboration by providing an open data platform for real-time sharing and project visualization, fostering efficiency and innovation across disciplines.
 links:
   - url: https://speckle.systems/
     label: Website

--- a/content/projects/vyssuals.mdx
+++ b/content/projects/vyssuals.mdx
@@ -1,5 +1,6 @@
 ---
 title: IFC Model Checker
+description: More info coming soon
 ---
 
 more info coming soon


### PR DESCRIPTION
This pull request introduces one-sentence descriptions to the front matter of the projects MDX files. These descriptions aim to provide a quick overview of each project’s purpose and impact. This helps the visitor on the website to understand faster what the projet is about without having to click on it.

Changes:
- Updated MDX files to include a `description` field in the front matter.
- Updated the ProjectsPartial to include the description.

Since it is a small change i thought i rather open a PR directly. No worries if this is not helpful and you want to skip it. :)