### PR TITLE
Layout Project Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ next-env.d.ts
 
 .idea
 *storybook.log
+pnpm-lock.yaml

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
 };
 
 const navItems = [
-  { name: "Projects", target: "/#projects" },
+  { name: "Projects", target: "/projects" },
   { name: "Events", target: "/#events" },
   { name: "Trainings", target: "/trainings" },
   { name: "About us", target: "/#who-is-behind-the-initiative" },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,6 @@ import Image from "next/image";
 import team from "../content/team.json";
 import partners from "../content/partners.json";
 
-import { saveForm } from "./actions";
 import ContactCard from "@/components/src/contactCard";
 import PartnerCard from "@/components/src/partnerCard";
 
@@ -61,12 +60,6 @@ export default function Home() {
             <Button
               target="/#contact-us"
               label="Want to submit a project yourself?"
-              type="primary"
-            />
-
-            <Button
-              target="/#contact-us"
-              label="Want to submit a challenge?"
               type="primary"
             />
           </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -17,6 +17,8 @@ export default function Projects() {
     {},
   );
 
+  //TODO: Improve the layout of this page especially regarding visual hierarchy
+
   return (
     <div className="mt-28 prose-h2:mt-0 md:mt-0 md:prose-h2:text-2xl md:prose-h3:text-xl">
       <Section>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,10 +1,9 @@
-import { getPosts, Section } from "@/components";
+import { Button, getPosts, Section } from "@/components";
 import {
   Maturity,
   parseProjects,
   Project,
 } from "@/components/src/projectUtils";
-import { Card } from "@/components/src/card";
 
 export default function Projects() {
   let projects = getPosts("projects");
@@ -36,18 +35,51 @@ export default function Projects() {
   };
 
   //TODO: Improve the layout of this page especially regarding visual hierarchy
+  //TODO: Either create a special card for projects in the project dir  or use a different layout
 
   return (
     <div className="mt-28 prose-h2:mt-0 md:mt-0 md:prose-h2:text-2xl md:prose-h3:text-xl">
+      <Section>
+        <h1 className="py-6 text-xl font-bold  md:text-4xl">Projects</h1>
+        <p>
+          The os.c marketplace is THE place to publish open source code with one
+          idea in mind: To reduce the incredible duplication of efforts that
+          really slows down innovation in the AECO industry. The idea of this
+          space is to collect a mix of open source projects. Small scripts, that
+          you wish you would have at hand instead of building it yourself.
+          Larger projects, that help you move faster. Any code, that is helpful
+          to others. Very soon, you will be able to push your open source code
+          via GitHub to our website. We will include your project in the
+          newsletter and organise an community call to make you and your code
+          known. This way, you will find code. But also heaps of talented
+          people, ready to push the industry further. Step by step and never
+          stopping.
+        </p>
+
+        <div className="pt-4">
+          <Button
+            target="/#contact-us"
+            label="Want to submit a project yourself?"
+            type="primary"
+          />
+
+          <Button
+            target="/#contact-us"
+            label="Want to submit a challenge?"
+            type="primary"
+          />
+        </div>
+      </Section>
+
       {Object.entries(projectsByMaturity).map(([projectMaturity, projects]) => (
         <Section
           key={projectMaturity}
           color={maturityColors[projectMaturity as Maturity]}
         >
           <div className="mb-16">
-            <h2 className="py-6 text-xl font-bold md:text-3xl">
+            <h1 className="py-6 text-xl font-bold  md:text-3xl">
               {projectMaturity}
-            </h2>
+            </h1>
 
             <p className="text-gray-500 text-sm">
               {maturitySubtext[projectMaturity as Maturity]}
@@ -55,14 +87,23 @@ export default function Projects() {
 
             <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-32">
               {projects.map(({ slug, title, description }, index) => (
-                <Card
+                <div
+                  className={`bg-${projectMaturity === "Sandbox" ? "slate-300" : "white"}`}
                   key={index}
-                  slug={slug}
-                  title={title}
-                  subtitle={description}
-                  color={projectMaturity === "Sandbox" ? "slate-300" : "white"}
-                  type="project"
-                />
+                >
+                  <div className="p-5">
+                    <h4 className="mb-2 mt-0 text-xl font-bold md:text-2xl">
+                      {title}
+                    </h4>
+                    <div className="mb-12">{description}</div>
+
+                    <Button
+                      label="More about the project"
+                      target={`/projects/${slug}`}
+                      type="primary"
+                    />
+                  </div>
+                </div>
               ))}
             </div>
           </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -3,7 +3,12 @@ import {
   Maturity,
   parseProjects,
   Project,
+  validMaturities,
 } from "@/components/src/projectUtils";
+
+function capitalizeFirstLetter(string: string): string {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
 
 export default function Projects() {
   let projects = getPosts("projects");
@@ -20,25 +25,25 @@ export default function Projects() {
     {} as Record<Maturity, Project[]>,
   );
 
-  const maturitySubtext: Record<Maturity, string> = {
-    Sandbox: "Experimental projects not yet widely tested in production",
-    Incubation:
-      "Projects used successfully in production by a small number of users",
-    Graduated:
-      "Projects considered stable, widely adopted and production ready, attracting hundreds of users and contributors",
-  };
-
-  const maturityOrder: Maturity[] = ["Sandbox", "Incubation", "Graduated"];
   const sortedProjectsByMaturity = Object.entries(projectsByMaturity).sort(
     ([a], [b]) =>
-      maturityOrder.indexOf(a as Maturity) -
-      maturityOrder.indexOf(b as Maturity),
+      validMaturities.indexOf(a as Maturity) -
+      validMaturities.indexOf(b as Maturity),
   );
 
+  //Set the color of the section based on the maturity of the projects
   const maturityColors: Record<Maturity, string> = {
-    Sandbox: "",
-    Incubation: "slate-300",
-    Graduated: "primary-500",
+    sandbox: "",
+    incubation: "slate-300",
+    graduated: "primary-500",
+  };
+
+  const maturitySubtext: Record<Maturity, string> = {
+    sandbox: "Experimental projects not yet widely tested in production",
+    incubation:
+      "Projects used successfully in production by a small number of users",
+    graduated:
+      "Projects considered stable, widely adopted and production ready, attracting hundreds of users and contributors",
   };
 
   //TODO: Improve the layout of this page especially regarding visual hierarchy
@@ -79,7 +84,7 @@ export default function Projects() {
         >
           <div className="mb-16">
             <h1 className="py-6 text-xl font-bold  md:text-3xl">
-              {projectMaturity}
+              {capitalizeFirstLetter(projectMaturity)}
             </h1>
 
             <p className="text-gray-500 text-sm">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -19,21 +19,25 @@ export default function Projects() {
 
   return (
     <div className="mt-28 prose-h2:mt-0 md:mt-0 md:prose-h2:text-2xl md:prose-h3:text-xl">
-      <Section title="Projects">
+      <Section>
         {Object.entries(projectsByMaturity).map(
           ([projectMaturity, projects]) => (
-            <div key={projectMaturity}>
-              <h3>{projectMaturity}</h3>
-              {projects.map(({ slug, title, description }, index) => (
-                <Card
-                  key={index}
-                  slug={slug}
-                  title={title}
-                  subtitle={description}
-                  color="slate-300"
-                  type="project"
-                />
-              ))}
+            <div key={projectMaturity} className="mb-16">
+              <h2 className="py-6 text-xl font-bold md:text-3xl">
+                {projectMaturity}
+              </h2>
+              <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-32">
+                {projects.map(({ slug, title, description }, index) => (
+                  <Card
+                    key={index}
+                    slug={slug}
+                    title={title}
+                    subtitle={description}
+                    color="slate-300"
+                    type="project"
+                  />
+                ))}
+              </div>
             </div>
           ),
         )}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -94,7 +94,7 @@ export default function Projects() {
             <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-5">
               {projects.map(({ slug, title, description }, index) => (
                 <div
-                  className={`bg-${projectMaturity === "Sandbox" ? "slate-300" : "white"}`}
+                  className={`bg-${projectMaturity === "sandbox" ? "slate-300" : "white"}`}
                   key={index}
                 >
                   <div className="p-5">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,43 @@
+import { getPosts, Section } from "@/components";
+import { parseProjects, Project } from "@/components/src/projectUtils";
+import { Card } from "@/components/src/card";
+
+export default function Projects() {
+  let projects = getPosts("projects");
+  let parsedProjects = parseProjects(projects);
+
+  const projectsByMaturity = parsedProjects.reduce<Record<string, Project[]>>(
+    (acc, project) => {
+      if (!acc[project.maturity]) {
+        acc[project.maturity] = [];
+      }
+      acc[project.maturity].push(project);
+      return acc;
+    },
+    {},
+  );
+
+  return (
+    <div className="mt-28 prose-h2:mt-0 md:mt-0 md:prose-h2:text-2xl md:prose-h3:text-xl">
+      <Section title="Projects">
+        {Object.entries(projectsByMaturity).map(
+          ([projectMaturity, projects]) => (
+            <div key={projectMaturity}>
+              <h3>{projectMaturity}</h3>
+              {projects.map(({ slug, title, description }, index) => (
+                <Card
+                  key={index}
+                  slug={slug}
+                  title={title}
+                  subtitle={description}
+                  color="slate-300"
+                  type="project"
+                />
+              ))}
+            </div>
+          ),
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -28,6 +28,13 @@ export default function Projects() {
       "Projects considered stable, widely adopted and production ready, attracting hundreds of users and contributors",
   };
 
+  const maturityOrder: Maturity[] = ["Sandbox", "Incubation", "Graduated"];
+  const sortedProjectsByMaturity = Object.entries(projectsByMaturity).sort(
+    ([a], [b]) =>
+      maturityOrder.indexOf(a as Maturity) -
+      maturityOrder.indexOf(b as Maturity),
+  );
+
   const maturityColors: Record<Maturity, string> = {
     Sandbox: "",
     Incubation: "slate-300",
@@ -62,16 +69,10 @@ export default function Projects() {
             label="Want to submit a project yourself?"
             type="primary"
           />
-
-          <Button
-            target="/#contact-us"
-            label="Want to submit a challenge?"
-            type="primary"
-          />
         </div>
       </Section>
 
-      {Object.entries(projectsByMaturity).map(([projectMaturity, projects]) => (
+      {sortedProjectsByMaturity.map(([projectMaturity, projects]) => (
         <Section
           key={projectMaturity}
           color={maturityColors[projectMaturity as Maturity]}
@@ -85,7 +86,7 @@ export default function Projects() {
               {maturitySubtext[projectMaturity as Maturity]}
             </p>
 
-            <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-32">
+            <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-5">
               {projects.map(({ slug, title, description }, index) => (
                 <div
                   className={`bg-${projectMaturity === "Sandbox" ? "slate-300" : "white"}`}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,12 +1,16 @@
 import { getPosts, Section } from "@/components";
-import { parseProjects, Project } from "@/components/src/projectUtils";
+import {
+  Maturity,
+  parseProjects,
+  Project,
+} from "@/components/src/projectUtils";
 import { Card } from "@/components/src/card";
 
 export default function Projects() {
   let projects = getPosts("projects");
   let parsedProjects = parseProjects(projects);
 
-  const projectsByMaturity = parsedProjects.reduce<Record<string, Project[]>>(
+  const projectsByMaturity = parsedProjects.reduce<Record<Maturity, Project[]>>(
     (acc, project) => {
       if (!acc[project.maturity]) {
         acc[project.maturity] = [];
@@ -14,36 +18,56 @@ export default function Projects() {
       acc[project.maturity].push(project);
       return acc;
     },
-    {},
+    {} as Record<Maturity, Project[]>,
   );
+
+  const maturitySubtext: Record<Maturity, string> = {
+    Sandbox: "Experimental projects not yet widely tested in production",
+    Incubation:
+      "Projects used successfully in production by a small number of users",
+    Graduated:
+      "Projects considered stable, widely adopted and production ready, attracting hundreds of users and contributors",
+  };
+
+  const maturityColors: Record<Maturity, string> = {
+    Sandbox: "",
+    Incubation: "slate-300",
+    Graduated: "primary-500",
+  };
 
   //TODO: Improve the layout of this page especially regarding visual hierarchy
 
   return (
     <div className="mt-28 prose-h2:mt-0 md:mt-0 md:prose-h2:text-2xl md:prose-h3:text-xl">
-      <Section>
-        {Object.entries(projectsByMaturity).map(
-          ([projectMaturity, projects]) => (
-            <div key={projectMaturity} className="mb-16">
-              <h2 className="py-6 text-xl font-bold md:text-3xl">
-                {projectMaturity}
-              </h2>
-              <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-32">
-                {projects.map(({ slug, title, description }, index) => (
-                  <Card
-                    key={index}
-                    slug={slug}
-                    title={title}
-                    subtitle={description}
-                    color="slate-300"
-                    type="project"
-                  />
-                ))}
-              </div>
+      {Object.entries(projectsByMaturity).map(([projectMaturity, projects]) => (
+        <Section
+          key={projectMaturity}
+          color={maturityColors[projectMaturity as Maturity]}
+        >
+          <div className="mb-16">
+            <h2 className="py-6 text-xl font-bold md:text-3xl">
+              {projectMaturity}
+            </h2>
+
+            <p className="text-gray-500 text-sm">
+              {maturitySubtext[projectMaturity as Maturity]}
+            </p>
+
+            <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-32">
+              {projects.map(({ slug, title, description }, index) => (
+                <Card
+                  key={index}
+                  slug={slug}
+                  title={title}
+                  subtitle={description}
+                  color={projectMaturity === "Sandbox" ? "slate-300" : "white"}
+                  type="project"
+                />
+              ))}
             </div>
-          ),
-        )}
-      </Section>
+          </div>
+        </Section>
+      ))}
     </div>
   );
 }

--- a/components/src/card/card.tsx
+++ b/components/src/card/card.tsx
@@ -22,7 +22,7 @@ export function Card({
 }: {
   title: string;
   slug?: string;
-  type?: "default" | "event" | "project" | "faq" | "partner" | "link";
+  type?: "default" | "event" | "project" | "faq" | "partner";
   color?: string;
   subtitle?: string;
   children?: ReactNode;
@@ -58,14 +58,6 @@ export function Card({
                 label="Learn more here"
                 target={() => setOpen(true)}
                 type="sidebar"
-              />
-            ),
-
-            link: (
-              <Button
-                label="See all Projects"
-                target={`${slug}`}
-                type="primary"
               />
             ),
 

--- a/components/src/card/card.tsx
+++ b/components/src/card/card.tsx
@@ -22,7 +22,7 @@ export function Card({
 }: {
   title: string;
   slug?: string;
-  type?: "default" | "event" | "project" | "faq" | "partner";
+  type?: "default" | "event" | "project" | "faq" | "partner" | "link";
   color?: string;
   subtitle?: string;
   children?: ReactNode;
@@ -59,6 +59,10 @@ export function Card({
                 target={() => setOpen(true)}
                 type="sidebar"
               />
+            ),
+
+            link: (
+              <Button label="To the Projects" target={`${slug}`} type="card" />
             ),
 
             partner: null,

--- a/components/src/card/card.tsx
+++ b/components/src/card/card.tsx
@@ -62,7 +62,11 @@ export function Card({
             ),
 
             link: (
-              <Button label="To the Projects" target={`${slug}`} type="card" />
+              <Button
+                label="See all Projects"
+                target={`${slug}`}
+                type="primary"
+              />
             ),
 
             partner: null,

--- a/components/src/page.tsx
+++ b/components/src/page.tsx
@@ -23,7 +23,12 @@ export default function Page({
   return (
     <div>
       <Section>
-        <Button target="/" label="Go back" type="secondary" icon="left" />
+        <Button
+          target="/projects"
+          label="Go back"
+          type="secondary"
+          icon="left"
+        />
         <h1 className="mb-8 mt-12 text-2xl font-bold md:mt-16 md:text-3xl">
           {page.metadata.title}
         </h1>

--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -13,10 +13,10 @@ export function ProjectsPartial() {
 
   const numberOfProjects = 3;
 
-  let showHighlighted = false;
+  let showFeatured = false;
 
-  const filteredProjects = showHighlighted
-    ? parsedProjects.filter((project) => project.highlighted)
+  const filteredProjects = showFeatured
+    ? parsedProjects.filter((project) => project.featured)
     : getRandomItems(parsedProjects, numberOfProjects);
 
   return (

--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -1,6 +1,8 @@
 import { getPosts } from "../utils";
 import { Card } from "../card";
 import { parseProjects } from "../projectUtils";
+import { Button } from "../button";
+import Link from "next/link";
 
 function getRandomItems<T>(array: T[], numItems: number): T[] {
   const shuffled = array.sort(() => 0.5 - Math.random());
@@ -35,13 +37,20 @@ export function ProjectsPartial() {
               />
             ))}
 
-        <Card
-          title="All Projects"
-          subtitle="View all projects"
-          slug={"/projects"}
-          type="link"
-          color="primary-500"
-        />
+        <div className={`bg-slate-300`}>
+          <div className="flex h-full flex-col p-5">
+            <h4 className="mb-2 mt-0 text-xl font-bold md:text-2xl">
+              All Projects
+            </h4>
+            <div className="mt-auto">
+              <Button
+                type="primary"
+                label="See all projects"
+                target={"./projects"}
+              ></Button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -2,13 +2,6 @@ import { getPosts } from "../utils";
 import { Card } from "../card";
 import { parseProjects } from "../projectUtils";
 
-export interface ProjectMap {
-  title: string;
-  slug: string;
-  highlighted: boolean;
-  state: string;
-}
-
 export function ProjectsPartial() {
   let projects = getPosts("projects");
   const parsedProjects = parseProjects(projects);

--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -2,20 +2,29 @@ import { getPosts } from "../utils";
 import { Card } from "../card";
 import { parseProjects } from "../projectUtils";
 
+function getRandomItems<T>(array: T[], numItems: number): T[] {
+  const shuffled = array.sort(() => 0.5 - Math.random());
+  return shuffled.slice(0, numItems);
+}
+
 export function ProjectsPartial() {
   let projects = getPosts("projects");
   const parsedProjects = parseProjects(projects);
 
-  let highlightedProjects = parsedProjects.filter(
-    (project) => project.highlighted,
-  );
+  const numberOfProjects = 3;
+
+  let showHighlighted = false;
+
+  const filteredProjects = showHighlighted
+    ? parsedProjects.filter((project) => project.highlighted)
+    : getRandomItems(parsedProjects, numberOfProjects);
 
   return (
     <div>
       <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-32">
-        {!highlightedProjects.length
+        {!filteredProjects.length
           ? "No published projects"
-          : highlightedProjects.map((e) => (
+          : filteredProjects.map((e) => (
               <Card
                 key={e.slug}
                 title={e.title}
@@ -31,7 +40,7 @@ export function ProjectsPartial() {
           subtitle="View all projects"
           slug={"/projects"}
           type="link"
-          color="slate-300"
+          color="primary-500"
         />
       </div>
     </div>

--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -1,27 +1,28 @@
 import { getPosts } from "../utils";
-
 import { Card } from "../card";
+import { parseProjects } from "../projectUtils";
+
+export interface ProjectMap {
+  title: string;
+  slug: string;
+  highlighted: boolean;
+  state: string;
+}
 
 export function ProjectsPartial() {
   let projects = getPosts("projects");
+  const parsedProjects = parseProjects(projects);
 
-  let parsedProjects = projects.map((e) => {
-    let project = { ...e.metadata.project };
-
-    project.title = e.metadata.title;
-    project.description = e.metadata.description;
-    project.slug = e.slug;
-
-    return project;
-  });
-  // .sort((a, b) => (a.start < b.start ? 1 : -1));
+  let highlightedProjects = parsedProjects.filter(
+    (project) => project.highlighted,
+  );
 
   return (
     <div>
       <div className="grid gap-12 py-10 md:mt-16 lg:grid-cols-2 lg:gap-32">
-        {!parsedProjects.length
+        {!highlightedProjects.length
           ? "No published projects"
-          : parsedProjects.map((e) => (
+          : highlightedProjects.map((e) => (
               <Card
                 key={e.slug}
                 title={e.title}

--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -25,6 +25,14 @@ export function ProjectsPartial() {
                 type="project"
               />
             ))}
+
+        <Card
+          title="All Projects"
+          subtitle="View all projects"
+          slug={"/projects"}
+          type="link"
+          color="slate-300"
+        />
       </div>
     </div>
   );

--- a/components/src/projectUtils.ts
+++ b/components/src/projectUtils.ts
@@ -1,5 +1,7 @@
 import projectMapJson from "../../content/project-map.json";
 
+const defaultMaturity: Maturity = "sandbox";
+
 //TODO: Put this file in the correct location
 //TODO: Improve import path for projectMapJson
 
@@ -19,11 +21,20 @@ export interface Project {
   description: string;
 }
 
-export type Maturity = "Sandbox" | "Incubation" | "Graduated";
+export const validMaturities = ["sandbox", "incubation", "graduated"] as const;
+export type Maturity = typeof validMaturities[number];
+
 
 const projectMapBySlug = new Map(
   projectMapJson.map((project) => [project.slug, project])
 );
+
+function parseMaturity(maturity: string): Maturity {
+  const cleanedMaturity = maturity.trim().toLowerCase();
+  return validMaturities.includes(cleanedMaturity as Maturity)
+    ? (cleanedMaturity as Maturity)
+    : defaultMaturity;
+}
 
 /**
  * Function to parse and merge project data with additional metadata from the json file
@@ -60,7 +71,7 @@ export function parseProjects(projects: any[]): Project[] {
       return {
         ...baseProject,
         ...extraData,
-        maturity: extraData.maturity as Maturity,
+        maturity: parseMaturity(extraData.maturity),
       };
     }
     return baseProject;

--- a/components/src/projectUtils.ts
+++ b/components/src/projectUtils.ts
@@ -25,6 +25,9 @@ const projectMapBySlug = new Map(
   projectMapJson.map((project) => [project.slug, project])
 );
 
+
+
+
 /**
  * Function to parse and merge project data with additional metadata from the json file
  * @param projects - Array of raw project data from getPosts function
@@ -38,7 +41,7 @@ const projectMapBySlug = new Map(
  * 
  * const rawProjects = getPosts("projects");
  * const parsedProjects = parseProjects(rawProjects);
- * ```
+ * ``` 
  */
 export function parseProjects(projects: any[]): Project[] {
   return projects.map((e) => {
@@ -51,10 +54,18 @@ export function parseProjects(projects: any[]): Project[] {
       title,
       description,
       slug,
+      maturity: e.maturity as Maturity,
     };
 
     // Merge extra data from projectMapBySlug
     const extraData = projectMapBySlug.get(slug);
-    return extraData ? { ...baseProject, ...extraData } : baseProject;
+    if (extraData) {
+      return {
+        ...baseProject,
+        ...extraData,
+        maturity: extraData.maturity as Maturity,
+      };
+    }
+    return baseProject;
   });
 }

--- a/components/src/projectUtils.ts
+++ b/components/src/projectUtils.ts
@@ -4,14 +4,14 @@ export interface ProjectMap {
   title: string;
   slug: string;
   highlighted: boolean;
-  state: string;
+  maturity: string;
 }
 
 export interface Project {
   title: string;
   slug: string;
   highlighted: boolean;
-  state: string;
+  maturity: string;
   description: string;
 }
 

--- a/components/src/projectUtils.ts
+++ b/components/src/projectUtils.ts
@@ -1,5 +1,8 @@
 import projectMapJson from "../../content/project-map.json";
 
+//TODO: Put this file in the correct location
+//TODO: Improve import path for projectMapJson
+
 export interface ProjectMap {
   title: string;
   slug: string;
@@ -7,6 +10,7 @@ export interface ProjectMap {
   maturity: string;
 }
 
+//TODO: Maybe rename this to something else than Project
 export interface Project {
   title: string;
   slug: string;

--- a/components/src/projectUtils.ts
+++ b/components/src/projectUtils.ts
@@ -25,9 +25,6 @@ const projectMapBySlug = new Map(
   projectMapJson.map((project) => [project.slug, project])
 );
 
-
-
-
 /**
  * Function to parse and merge project data with additional metadata from the json file
  * @param projects - Array of raw project data from getPosts function

--- a/components/src/projectUtils.ts
+++ b/components/src/projectUtils.ts
@@ -1,0 +1,54 @@
+import projectMapJson from "../../content/project-map.json";
+
+export interface ProjectMap {
+  title: string;
+  slug: string;
+  highlighted: boolean;
+  state: string;
+}
+
+export interface Project {
+  title: string;
+  slug: string;
+  highlighted: boolean;
+  state: string;
+  description: string;
+}
+
+const projectMapBySlug = new Map(
+  projectMapJson.map((project) => [project.slug, project])
+);
+
+/**
+ * Function to parse and merge project data with additional metadata from the json file
+ * @param projects - Array of raw project data from getPosts function
+ * @returns Array of parsed and merged project data
+ * 
+ * Usage example:
+ * 
+ * ```typescript
+ * import { getPosts } from "../utils/projectUtils";
+ * import { parseProjects } from "./projectUtils";
+ * 
+ * const rawProjects = getPosts("projects");
+ * const parsedProjects = parseProjects(rawProjects);
+ * ```
+ */
+export function parseProjects(projects: any[]): Project[] {
+  return projects.map((e) => {
+    const { title, description, project: projectMetadata } = e.metadata;
+    const { slug } = e;
+
+    // Base project object from metadata
+    const baseProject: Project = {
+      ...projectMetadata,
+      title,
+      description,
+      slug,
+    };
+
+    // Merge extra data from projectMapBySlug
+    const extraData = projectMapBySlug.get(slug);
+    return extraData ? { ...baseProject, ...extraData } : baseProject;
+  });
+}

--- a/components/src/projectUtils.ts
+++ b/components/src/projectUtils.ts
@@ -7,7 +7,7 @@ export interface ProjectMap {
   title: string;
   slug: string;
   highlighted: boolean;
-  maturity: string;
+  maturity: Maturity;
 }
 
 //TODO: Maybe rename this to something else than Project
@@ -15,9 +15,11 @@ export interface Project {
   title: string;
   slug: string;
   highlighted: boolean;
-  maturity: string;
+  maturity: Maturity;
   description: string;
 }
+
+export type Maturity = "Sandbox" | "Incubation" | "Graduated";
 
 const projectMapBySlug = new Map(
   projectMapJson.map((project) => [project.slug, project])

--- a/components/src/projectUtils.ts
+++ b/components/src/projectUtils.ts
@@ -6,7 +6,7 @@ import projectMapJson from "../../content/project-map.json";
 export interface ProjectMap {
   title: string;
   slug: string;
-  highlighted: boolean;
+  featured: boolean;
   maturity: Maturity;
 }
 
@@ -14,7 +14,7 @@ export interface ProjectMap {
 export interface Project {
   title: string;
   slug: string;
-  highlighted: boolean;
+  featured: boolean;
   maturity: Maturity;
   description: string;
 }

--- a/content/project-map.json
+++ b/content/project-map.json
@@ -2,73 +2,73 @@
   {
     "title": "Bonsai",
     "slug": "bonsai",
-    "highlighted": true,
+    "featured": true,
     "maturity": "Graduated"
   },
   {
     "title": "Compas",
     "slug": "compas",
-    "highlighted": true,
+    "featured": true,
     "maturity": "Graduated"
   },
   {
     "title": "IFC Model Checker",
     "slug": "ifc-model-checker",
-    "highlighted": true,
+    "featured": true,
     "maturity": "Sandbox"
   },
   {
     "title": "PyRevit",
     "slug": "pyrevit",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Graduated"
   },
   {
     "title": "Sprint",
     "slug": "sprint",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Incubation"
   },
   {
     "title": "Vyssuals",
     "slug": "vyssuals",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Incubation"
   },
   {
     "title": "Circular Construction Co-Pilot",
     "slug": "circular-construction-co-pilot",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Sandbox"
   },
   {
     "title": "IFC LCA",
     "slug": "ifc-lca",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Incubation"
   },
   {
     "title": "LCAX and EPDX",
     "slug": "lcax-and-epdx",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Sandbox"
   },
   {
     "title": "Speckle",
     "slug": "speckle",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Graduated"
   },
   {
     "title": "That Open Company",
     "slug": "that-open-company",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Graduated"
   },
   {
     "title": "Calc",
     "slug": "calc",
-    "highlighted": false,
+    "featured": false,
     "maturity": "Incubation"
   }
 ]

--- a/content/project-map.json
+++ b/content/project-map.json
@@ -3,72 +3,72 @@
     "title": "Bonsai",
     "slug": "bonsai",
     "featured": true,
-    "maturity": "Graduated"
+    "maturity": "graduated"
   },
   {
     "title": "Compas",
     "slug": "compas",
     "featured": true,
-    "maturity": "Graduated"
+    "maturity": "graduated"
   },
   {
     "title": "IFC Model Checker",
     "slug": "ifc-model-checker",
     "featured": true,
-    "maturity": "Sandbox"
+    "maturity": "sandbox"
   },
   {
     "title": "PyRevit",
     "slug": "pyrevit",
     "featured": false,
-    "maturity": "Graduated"
+    "maturity": "graduated"
   },
   {
     "title": "Sprint",
     "slug": "sprint",
     "featured": false,
-    "maturity": "Incubation"
+    "maturity": "incubation"
   },
   {
     "title": "Vyssuals",
     "slug": "vyssuals",
     "featured": false,
-    "maturity": "Incubation"
+    "maturity": "incubation"
   },
   {
     "title": "Circular Construction Co-Pilot",
     "slug": "circular-construction-co-pilot",
     "featured": false,
-    "maturity": "Sandbox"
+    "maturity": "sandbox"
   },
   {
     "title": "IFC LCA",
     "slug": "ifc-lca",
     "featured": false,
-    "maturity": "Incubation"
+    "maturity": "incubation"
   },
   {
     "title": "LCAX and EPDX",
     "slug": "lcax-and-epdx",
     "featured": false,
-    "maturity": "Sandbox"
+    "maturity": "sandbox"
   },
   {
     "title": "Speckle",
     "slug": "speckle",
     "featured": false,
-    "maturity": "Graduated"
+    "maturity": "graduated"
   },
   {
     "title": "That Open Company",
     "slug": "that-open-company",
     "featured": false,
-    "maturity": "Graduated"
+    "maturity": "graduated"
   },
   {
     "title": "Calc",
     "slug": "calc",
     "featured": false,
-    "maturity": "Incubation"
+    "maturity": "incubation"
   }
 ]

--- a/content/project-map.json
+++ b/content/project-map.json
@@ -1,0 +1,68 @@
+[
+  {
+    "title": "Bonsai",
+    "slug": "bonsai",
+    "highlighted": true,
+    "state": "sandbox"
+  },
+  {
+    "title": "Compas",
+    "slug": "compas",
+    "highlighted": true,
+    "state": "sandbox"
+  },
+  {
+    "title": "IFC Model Checker",
+    "slug": "ifc-model-checker",
+    "highlighted": true,
+    "state": "sandbox"
+  },
+  {
+    "title": "PyRevit",
+    "slug": "pyrevit",
+    "highlighted": false,
+    "state": "sandbox"
+  },
+  {
+    "title": "Sprint",
+    "slug": "sprint",
+    "highlighted": false,
+    "state": "sandbox"
+  },
+  {
+    "title": "Vyssuals",
+    "slug": "vyssuals",
+    "highlighted": false,
+    "state": "sandbox"
+  },
+  {
+    "title": "Circular Construction Co-Pilot",
+    "slug": "circular-construction-co-pilot",
+    "highlighted": false,
+    "state": "sandbox"
+  },
+  {
+    "title": "IFC LCA",
+    "slug": "ifc-lca",
+    "highlighted": false,
+    "state": "sandbox"
+  },
+  {
+    "title": "LCAX and EPDX",
+    "slug": "lcax-and-epdx",
+    "highlighted": false,
+    "state": "sandbox"
+  },
+  {
+    "title": "Speckle",
+    "slug": "speckle",
+    "highlighted": false,
+    "state": "sandbox"
+  },
+  {
+    "title": "That Open Company",
+    "slug": "that-open-company",
+    "highlighted": false,
+    "state": "sandbox"
+  }
+]

--- a/content/project-map.json
+++ b/content/project-map.json
@@ -3,43 +3,43 @@
     "title": "Bonsai",
     "slug": "bonsai",
     "highlighted": true,
-    "maturity": "Sandbox"
+    "maturity": "Graduated"
   },
   {
     "title": "Compas",
     "slug": "compas",
     "highlighted": true,
-    "maturity": "Sandbox"
+    "maturity": "Graduated"
   },
   {
     "title": "IFC Model Checker",
     "slug": "ifc-model-checker",
     "highlighted": true,
-    "maturity": "Graduated"
+    "maturity": "Sandbox"
   },
   {
     "title": "PyRevit",
     "slug": "pyrevit",
     "highlighted": false,
-    "maturity": "Sandbox"
+    "maturity": "Graduated"
   },
   {
     "title": "Sprint",
     "slug": "sprint",
     "highlighted": false,
-    "maturity": "Sandbox"
+    "maturity": "Incubation"
   },
   {
     "title": "Vyssuals",
     "slug": "vyssuals",
     "highlighted": false,
-    "maturity": "Sandbox"
+    "maturity": "Incubation"
   },
   {
     "title": "Circular Construction Co-Pilot",
     "slug": "circular-construction-co-pilot",
     "highlighted": false,
-    "maturity": "Incubation"
+    "maturity": "Sandbox"
   },
   {
     "title": "IFC LCA",
@@ -63,6 +63,12 @@
     "title": "That Open Company",
     "slug": "that-open-company",
     "highlighted": false,
-    "maturity": "Sandbox"
+    "maturity": "Graduated"
+  },
+  {
+    "title": "Calc",
+    "slug": "calc",
+    "highlighted": false,
+    "maturity": "Incubation"
   }
 ]

--- a/content/project-map.json
+++ b/content/project-map.json
@@ -15,7 +15,7 @@
     "title": "IFC Model Checker",
     "slug": "ifc-model-checker",
     "highlighted": true,
-    "maturity": "Growth"
+    "maturity": "Graduated"
   },
   {
     "title": "PyRevit",
@@ -39,13 +39,13 @@
     "title": "Circular Construction Co-Pilot",
     "slug": "circular-construction-co-pilot",
     "highlighted": false,
-    "maturity": "Sandbox"
+    "maturity": "Incubation"
   },
   {
     "title": "IFC LCA",
     "slug": "ifc-lca",
     "highlighted": false,
-    "maturity": "Incubation "
+    "maturity": "Incubation"
   },
   {
     "title": "LCAX and EPDX",
@@ -57,7 +57,7 @@
     "title": "Speckle",
     "slug": "speckle",
     "highlighted": false,
-    "maturity": "Growth"
+    "maturity": "Graduated"
   },
   {
     "title": "That Open Company",

--- a/content/project-map.json
+++ b/content/project-map.json
@@ -3,66 +3,66 @@
     "title": "Bonsai",
     "slug": "bonsai",
     "highlighted": true,
-    "state": "sandbox"
+    "maturity": "Sandbox"
   },
   {
     "title": "Compas",
     "slug": "compas",
     "highlighted": true,
-    "state": "sandbox"
+    "maturity": "Sandbox"
   },
   {
     "title": "IFC Model Checker",
     "slug": "ifc-model-checker",
     "highlighted": true,
-    "state": "sandbox"
+    "maturity": "Growth"
   },
   {
     "title": "PyRevit",
     "slug": "pyrevit",
     "highlighted": false,
-    "state": "sandbox"
+    "maturity": "Sandbox"
   },
   {
     "title": "Sprint",
     "slug": "sprint",
     "highlighted": false,
-    "state": "sandbox"
+    "maturity": "Sandbox"
   },
   {
     "title": "Vyssuals",
     "slug": "vyssuals",
     "highlighted": false,
-    "state": "sandbox"
+    "maturity": "Sandbox"
   },
   {
     "title": "Circular Construction Co-Pilot",
     "slug": "circular-construction-co-pilot",
     "highlighted": false,
-    "state": "sandbox"
+    "maturity": "Sandbox"
   },
   {
     "title": "IFC LCA",
     "slug": "ifc-lca",
     "highlighted": false,
-    "state": "sandbox"
+    "maturity": "Incubation "
   },
   {
     "title": "LCAX and EPDX",
     "slug": "lcax-and-epdx",
     "highlighted": false,
-    "state": "sandbox"
+    "maturity": "Sandbox"
   },
   {
     "title": "Speckle",
     "slug": "speckle",
     "highlighted": false,
-    "state": "sandbox"
+    "maturity": "Growth"
   },
   {
     "title": "That Open Company",
     "slug": "that-open-company",
     "highlighted": false,
-    "state": "sandbox"
+    "maturity": "Sandbox"
   }
 ]


### PR DESCRIPTION
### Description

This pull request proposes the following changes:

- Adding header text to projects & call to actions
- Adding visual section differences between section/ maturity levels
- Adding subtext to each maturity level
- Changing **Incubating** to **Growth**
- Add some type safety

### Remarks
The text for the Projects is now hardcoded to the project page itself, probably best to change this in the future. Also, the text is now duplicated on the index page as well @MaximilianVomhof probably something to discuss what content text should be on the index page and what inside the project page. 

@n0rdlicht didn't use the `Card` component, since the button didn't work in this case with different backgrounds (darker gray/yellow + white card background). For the moment, I just copied some code to get it going for the hackathon, but maybe something to have a look at in the future.