### PR TITLE
fix: make images use absolute path

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,6 @@ import {
 } from "@opensource-construction/components";
 import Image from "next/image";
 import team from "../content/team.json";
-
 import ContactCard from "@/components/src/contactCard";
 import { PartnersPartial } from "@/components/src/partials/partners";
 

--- a/components/src/contactCard.tsx
+++ b/components/src/contactCard.tsx
@@ -18,7 +18,7 @@ const ContactCard = (contactProps: ContactProps) => {
     <div className="grid grid-cols-3 gap-4">
       <div className="flex-wrap">
         <img
-          src={`images/team/${contactProps.image}`}
+          src={`/images/team/${contactProps.image}`}
           alt={contactProps.name}
           className="m-6 h-24 w-24 min-w-24 rounded-full border border-slate-500 object-contain shadow-lg"
         />

--- a/components/src/partnerCard.tsx
+++ b/components/src/partnerCard.tsx
@@ -43,7 +43,7 @@ const PartnerCard = ({
     >
       <div className="flex  flex-col items-center justify-center gap-2 p-4 sm:p-6">
         <img
-          src={`images/partners/${logo}`}
+          src={`/images/partners/${logo}`}
           alt={name}
           className={`object-contain transition-all duration-300 ${sizeClasses[size]}`}
         />


### PR DESCRIPTION
Partner logos and team images didn't use absolute path.

### Image Path Updates:
* [`components/src/contactCard.tsx`](diffhunk://#diff-73d56d7b51b6b252f2ee2d84c2b3a2adbe5eb3e1bb4b0123731f78fe72b3d187L21-R21): Updated the image path for the `ContactCard` component to use an absolute path.
* [`components/src/partnerCard.tsx`](diffhunk://#diff-f31c9a0b3ae4d5ae8dcb1580c4518654a9736d90c542da29187f626701a2b713L46-R46): Updated the image path for the `PartnerCard` component to use an absolute path.
