### PR TITLE
Fix: button target path in ProjectsPartial component

### DIFF
--- a/components/src/partials/projects.tsx
+++ b/components/src/partials/projects.tsx
@@ -43,7 +43,7 @@ export function ProjectsPartial() {
               <Button
                 type="primary"
                 label="See all projects"
-                target={"./projects"}
+                target={"/projects"}
               ></Button>
             </div>
           </div>


### PR DESCRIPTION
This pull request includes a minor update to the `ProjectsPartial` component. The change updates the `target` property of the "See all projects" button to use an absolute path instead of a relative path.

* [`components/src/partials/projects.tsx`](diffhunk://#diff-de4ee79ff312daece7fb3a1ab2ddaaffdf542bbb0002e92bb7e1ba2030dcf69dL46-R46): Changed the `target` value for the "See all projects" button from `./projects` to `/projects` to ensure it correctly navigates to the projects page.